### PR TITLE
Now on Tap overlay

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -377,7 +377,7 @@
          This needs to match the constants in
          policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
     -->
-    <integer name="config_doubleTapOnHomeBehavior">0</integer>
+    <!--<integer name="config_doubleTapOnHomeBehavior">0</integer>--> <!-- TODO: Duplicated on line 353 -->
 
     <!-- enable doze powersaving mode -->
     <bool name="config_enableAutoPowerModes">true</bool>

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -378,6 +378,11 @@
          policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
     -->
     <!--<integer name="config_doubleTapOnHomeBehavior">0</integer>--> <!-- TODO: Duplicated on line 353 -->
+    
+    <!-- TODO: Enables HW HOME as input for Now On Tap (or Search on screen)
+         This flag must be set to allow the use of Home hardware button for assistant on screen search.
+         Without, only software navigation bar enables Now on Tap behaviour -->
+    <bool name="config_hwKeysPref">true</bool>
 
     <!-- enable doze powersaving mode -->
     <bool name="config_enableAutoPowerModes">true</bool>


### PR DESCRIPTION
Hi AndropaX, I'm a user of your RR-7.1 rom for Mi 4C. I'd really like to use Now on Tap, that seems to work only when software navigation key is enabled (`qemu.hw.mainkeys=0` in `build.prop`).

To enable it, a new key must be added to `config.xml` file, as suggested by [XDA Assist team](http://forum.xda-developers.com/showpost.php?p=70289151&postcount=4). I think it is something that can be really useful to all user, so I decided to prepare a pull request on your repo. It is really more simple to disable Now on Tap on compiled ROM, than enabling it.

I hope you will insert it in the next update. 

Thank you